### PR TITLE
Clean Forge, Clean Tests, and Time Bug Fixes

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 src = 'src'
 out = 'out'
 libs = ['lib']

--- a/src/hdmap.sol
+++ b/src/hdmap.sol
@@ -12,7 +12,7 @@ import { ReentrancyGuard } from "./ReentrancyGuard.sol";
 uint256 constant avgEthereumBlockTimeSeconds = 12 seconds;
 uint256 constant daySeconds = 86400 seconds;
 uint256 constant dayBlocks = daySeconds / avgEthereumBlockTimeSeconds;
-uint256 constant yearDays = 356 days;
+uint256 constant yearDays = 356;
 uint256 constant yearBlocks = dayBlocks * yearDays;
 
 struct Deed {

--- a/src/hdmap.t.sol
+++ b/src/hdmap.t.sol
@@ -84,8 +84,8 @@ contract HdmapTest is Test {
   }
 
   function testConstants() public {
-    assertTrue(dayBlocks != 0);
-    assertTrue(yearBlocks != 0);
+    assertEq(dayBlocks, 0x1C20);
+    assertEq(yearBlocks, 0x271C80);
   }
 
   function testIfBeneficiaryRentrancyIsGuarded() public {

--- a/src/hdmap.t.sol
+++ b/src/hdmap.t.sol
@@ -161,8 +161,7 @@ contract HdmapTest is Test {
   }
 
   function encodeZoneAndName(address zone, bytes32 name) public pure returns (bytes memory) {
-    bytes12 empty = 0x000000000000;
-    return abi.encodePacked(empty, bytes20(zone), name);
+    return abi.encode(zone, name);
   }
 
   function testEncodeZoneAndName() public {


### PR DESCRIPTION
Going back to our prior chats, I still think it makes sense to just remove the deploy time calculations for the number of blocks in a year and just set your own value. It's sort of arbitrary after all. But anyway deferring to following your pattern here w/ a fix.

Also keeping 356 days, assuming this was intentional on your end?